### PR TITLE
Add zsh to setup script and tmux resize shortcut

### DIFF
--- a/setup_dotfiles.sh
+++ b/setup_dotfiles.sh
@@ -36,6 +36,7 @@ links=(
   ~/.rspec
   ~/.tmux.conf
   ~/.vimrc
+  ~/.zsh
   ~/.zshenv
   ~/.zshrc
 )
@@ -53,6 +54,7 @@ files=(
   ~/dotfiles/rspec
   ~/dotfiles/tmux.conf
   ~/dotfiles/vim/vimrc
+  ~/dotfiles/zsh
   ~/dotfiles/zshenv
   ~/dotfiles/zshrc
 )

--- a/tmux.conf
+++ b/tmux.conf
@@ -32,6 +32,16 @@ set -g status-right " #(battery -t) #(date '+%a, %b %d - %I:%M') "
 
 set -g history-limit 10000
 
+bind -n S-Left resize-pane -L 2
+bind -n S-Right resize-pane -R 2
+bind -n S-Down resize-pane -D 1
+bind -n S-Up resize-pane -U 1
+
+bind -n C-Left resize-pane -L 10
+bind -n C-Right resize-pane -R 10
+bind -n C-Down resize-pane -D 5
+bind -n C-Up resize-pane -U 5
+
 # act like vim
 # setw -g mode-keys vi
 # bind-key -r C-h select-window -t :-


### PR DESCRIPTION
Why:
The setup script missed creating a symlink for the zsh folder in
~/dotfiles/zsh and I wanted to have a short cut for tmux pane resize
command.

This PR:
Adds the link to be setup for zsh in the setup script and the tmux key
bindings for resizing the pane.